### PR TITLE
Added a first SKILL for ES|QL queries

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -29,10 +29,15 @@ Queries can be written in several formats, but the most common ones, which are e
 ## Extension prerequisites
 
 - The user must have an existing [Elastic Cloud](https://cloud.elastic.co) account, with an active Elasticsearch cluster and its counterpart Kibana instance.
-- The Kibana instance must have the Elastic Agent Builder feature enabled.
+- The Kibana instance must have the Elastic Agent Builder feature enabled (this is required only for using MCP, for the SKILLs this is not required).
   Agent Builder's tools are exposed as tools in the MCP server that this extension consumes; adding, removing or modifying tools must be done in the Kibana UI.
 
 For this extension to connect to its MCP server, two environment variables must be set:
 
 - `ELASTIC_MCP_URL`: the full URL to your hosted MCP server
 - `ELASTIC_API_KEY`: the API key for your hosted MCP server
+
+This extension provides also a set of SKILLs in the `/skills` folder. For these two environment variables must be set:
+
+- `ELASTIC_URL`: the full URL to your hosted Elasticsearch
+- `ELASTIC_API_KEY`: the API key for your hosted Elasticsearch

--- a/skills/esql/SKILL.md
+++ b/skills/esql/SKILL.md
@@ -4,7 +4,7 @@ description: >
   Interact with Elasticsearch using ES|QL and curl. Use when querying, managing indices, 
   checking cluster Elasticsearch. Requires endpoint URL and API key.
   Covers: search (using ES|QL), index management, mappings.
-compatiblity: Requires Elsticsearch, curl, jq, printenv.
+compatiblity: Requires Elasticsearch, curl, jq, printenv.
 ---
 
 # Elasticsearch

--- a/skills/esql/SKILL.md
+++ b/skills/esql/SKILL.md
@@ -1,0 +1,171 @@
+---
+name: esql
+description: >
+  Interact with Elasticsearch using ES|QL and curl. Use when querying, managing indices, 
+  checking cluster Elasticsearch. Requires endpoint URL and API key.
+  Covers: search (using ES|QL), index management, mappings.
+compatiblity: Requires Elsticsearch, curl, jq, printenv.
+---
+
+# Elasticsearch
+
+All Elasticsearch interaction is via REST API using `curl`. No SDK or client library required.
+
+## Authentication
+
+To connect to Elasticsearch, a URL and an API key are required. These must be provided using two environment variables:
+`ELASTIC_URL` and `ELASTIC_API_KEY`.
+
+If either of these environment variables is not set, ask the user to provide the missing value(s) and instruct them to export the variables for the current session.
+
+When requesting the `ELASTIC_API_KEY`, do not display it in plaintext. Instead, mask each character with an asterisk.
+
+## IMPORTANT
+
+Always follow these rules:
+- Use only the APIs provided in this skill.
+- Never display the `ELASTIC_URL` and `ELASTIC_API_KEY` in your response.
+
+## Available APIs
+
+The available APIs to interact with Elasticsearch are:
+
+### Health Check
+
+The following command can be used to check if Elasticsearch is running properly.
+The cluster health can be green=ok, yellow=warning, red=problem.
+
+```bash
+curl -s "${ELASTIC_URL%/}/_cluster/health" -H "Authorization: ApiKey $(printenv ELASTIC_API_KEY)"
+```
+
+### List indices
+
+The following command returns the list of all the Elasticsearch indices (excluding the internals).
+
+```bash
+curl -s "${ELASTIC_URL%/}/_cat/indices/*,-.internal.*?format=json" -H "Authorization: ApiKey $(printenv ELASTIC_API_KEY)"
+```
+
+### Get mapping of an index
+
+The following command returns the mapping of an index. Replace `my-index` with the one from the user's request.
+
+```bash
+curl -s "${ELASTIC_URL%/}/my-index/_mapping" -H "Authorization: ApiKey $(printenv ELASTIC_API_KEY)"
+```
+
+### Search (using Elasticsearch Query Language, ES|QL)
+
+When a user requests to search for data in Elasticsearch, follow this procedure:
+
+1. **Determine the target index**
+- Identify the appropriate Elasticsearch index based on the user’s request.
+- If the index is not explicitly specified, use the List Indices API to retrieve available indices.
+- Select the index that best matches the user’s query.
+
+2. **Retrieve Index Mapping**
+- Check whether the index mapping is already available.
+- If not, use the Get Mappings API to retrieve the index mapping.
+- Store the mapping information for use in query construction.
+
+3. **Read the ES|QL reference** for syntax details:
+   - [ES|QL Complete Reference](references/esql-reference.md)
+
+4. **Generate the query** following ES|QL syntax:
+   - Start with `FROM index-pattern`
+   - Add `WHERE` for filtering
+   - Use `EVAL` for computed fields
+   - Use `STATS ... BY` for aggregations
+   - Add `SORT` and `LIMIT` as needed
+
+3. **Translate the user's request into ES|QL**
+- Translate the user's request in an ES|QL query using the index mapping to translate the user’s request.
+- Ensure the query aligns with the field types and structure defined in the mapping.
+
+4. Execute the Query
+- Execute the generated ES|QL query using the following API command (replace `insert-here-the-query` with the translated ES|QL query):
+```bash
+curl -s -X POST "${ELASTIC_URL%/}/_query" \
+  -H "Authorization: ApiKey $(printenv ELASTIC_API_KEY)" \
+  -H "Content-Type: application/json" \
+  -d "$(jq -n --arg q "insert-here-the-query" '{query: $q}')"
+```
+
+## ES|QL Quick Reference
+
+### Basic Structure
+
+```
+FROM index-pattern
+| WHERE condition
+| EVAL new_field = expression
+| STATS aggregation BY grouping
+| SORT field DESC
+| LIMIT n
+```
+
+### Common Patterns
+
+**Filter and limit:**
+
+```esql
+FROM logs-*
+| WHERE @timestamp > NOW() - 24 hours AND level == "error"
+| SORT @timestamp DESC
+| LIMIT 100
+```
+
+**Aggregate by time:**
+
+```esql
+FROM metrics-*
+| WHERE @timestamp > NOW() - 7 days
+| STATS avg_cpu = AVG(cpu.percent) BY bucket = DATE_TRUNC(1 hour, @timestamp)
+| SORT bucket DESC
+```
+
+**Top N with count:**
+
+```esql
+FROM web-logs
+| STATS count = COUNT(*) BY response.status_code
+| SORT count DESC
+| LIMIT 10
+```
+
+**Text search (8.17+):**
+
+```esql
+FROM documents METADATA _score
+| WHERE MATCH(content, "search terms")
+| SORT _score DESC
+| LIMIT 20
+```
+
+## Full Reference
+
+For complete ES|QL syntax including all commands, functions, and operators, read:
+
+- [ES|QL Complete Reference](references/esql-reference.md)
+- [Query Patterns](references/query-patterns.md) - Natural language to ES|QL translation
+- [Generation Tips](references/generation-tips.md) - Best practices for query generation
+
+## Error Handling
+
+When query execution fails, the script returns:
+
+- The generated ES|QL query
+- The error message from Elasticsearch
+- Suggestions for common issues
+
+**Common issues:**
+
+- Field doesn't exist → Check schema with the Get Mapping API
+- Type mismatch → Use type conversion functions (TO_STRING, TO_INTEGER, etc.)
+- Syntax error → Review ES|QL reference for correct syntax
+- No results → Check time range and filter conditions
+
+### Search tips
+
+- **`?size=0`** on search requests when you only want aggregations (skip hits).

--- a/skills/esql/SKILL.md
+++ b/skills/esql/SKILL.md
@@ -13,12 +13,8 @@ All Elasticsearch interaction is via REST API using `curl`. No SDK or client lib
 
 ## Authentication
 
-To connect to Elasticsearch, a URL and an API key are required. These must be provided using two environment variables:
+To connect to Elasticsearch, a URL and an API key are required. These are stored in two environment variables:
 `ELASTIC_URL` and `ELASTIC_API_KEY`.
-
-If either of these environment variables is not set, ask the user to provide the missing value(s) and instruct them to export the variables for the current session.
-
-When requesting the `ELASTIC_API_KEY`, do not display it in plaintext. Instead, mask each character with an asterisk.
 
 ## IMPORTANT
 

--- a/skills/esql/SKILL.md
+++ b/skills/esql/SKILL.md
@@ -79,11 +79,11 @@ When a user requests to search for data in Elasticsearch, follow this procedure:
    - Use `STATS ... BY` for aggregations
    - Add `SORT` and `LIMIT` as needed
 
-3. **Translate the user's request into ES|QL**
+5. **Translate the user's request into ES|QL**
 - Translate the user's request in an ES|QL query using the index mapping to translate the user’s request.
 - Ensure the query aligns with the field types and structure defined in the mapping.
 
-4. Execute the Query
+6. Execute the Query
 - Execute the generated ES|QL query using the following API command (replace `insert-here-the-query` with the translated ES|QL query):
 ```bash
 curl -s -X POST "${ELASTIC_URL%/}/_query" \

--- a/skills/esql/references/esql-reference.md
+++ b/skills/esql/references/esql-reference.md
@@ -1,0 +1,713 @@
+# ES|QL Complete Reference
+
+ES|QL (Elasticsearch Query Language) is a piped query language for filtering, transforming, and analyzing data in Elasticsearch. It uses pipes (`|`) to chain commands together.
+
+## Query Structure
+
+```
+source-command
+| processing-command1
+| processing-command2
+| ...
+```
+
+An ES|QL query starts with a **source command** followed by zero or more **processing commands** separated by pipes.
+
+---
+
+## Source Commands
+
+Source commands produce tables, typically from Elasticsearch data.
+
+### FROM
+
+Retrieves data from indices, data streams, or aliases.
+
+**Syntax:**
+
+```
+FROM index_pattern [METADATA fields]
+```
+
+**Examples:**
+
+```esql
+// Basic usage
+FROM logs-*
+
+// Multiple indices
+FROM employees-00001, other-employees-*
+
+// With metadata
+FROM logs-* METADATA _id, _index
+
+// Date math
+FROM <logs-{now/d}>
+
+// Cross-cluster search
+FROM cluster_one:logs-*, cluster_two:logs-*
+```
+
+**Note:** Without explicit `LIMIT`, queries default to 1000 rows.
+
+### ROW
+
+Creates a row with literal values. Useful for testing.
+
+**Syntax:**
+
+```
+ROW column1 = value1 [, column2 = value2, ...]
+```
+
+**Examples:**
+
+```esql
+ROW a = 1, b = "two", c = null
+ROW x = [1, 2, 3]
+ROW greeting = "hello", pi = 3.14159
+```
+
+### SHOW
+
+Returns information about the deployment.
+
+**Syntax:**
+
+```
+SHOW INFO
+```
+
+---
+
+## Processing Commands
+
+Processing commands transform the input table.
+
+### WHERE
+
+Filters rows based on a boolean condition.
+
+**Syntax:**
+
+```
+WHERE condition
+```
+
+**Examples:**
+
+```esql
+FROM employees
+| WHERE salary > 50000
+
+FROM logs-*
+| WHERE status_code >= 400 AND status_code < 500
+
+FROM events
+| WHERE message LIKE "*error*"
+
+FROM users
+| WHERE name RLIKE "J.*n"
+
+FROM data
+| WHERE field IS NOT NULL
+```
+
+### EVAL
+
+Adds or replaces columns with calculated values.
+
+**Syntax:**
+
+```
+EVAL column1 = expression1 [, column2 = expression2, ...]
+```
+
+**Examples:**
+
+```esql
+FROM employees
+| EVAL annual_salary = monthly_salary * 12
+
+FROM logs
+| EVAL duration_ms = end_time - start_time
+| EVAL duration_sec = duration_ms / 1000
+
+FROM data
+| EVAL full_name = CONCAT(first_name, " ", last_name)
+| EVAL is_adult = age >= 18
+```
+
+### STATS ... BY
+
+Aggregates data, optionally grouped by columns.
+
+**Syntax:**
+
+```
+STATS aggregation1 [, aggregation2, ...] [BY grouping1, grouping2, ...]
+```
+
+**Examples:**
+
+```esql
+// Simple count
+FROM logs-*
+| STATS count = COUNT(*)
+
+// Multiple aggregations
+FROM sales
+| STATS
+    total = SUM(amount),
+    avg_amount = AVG(amount),
+    max_amount = MAX(amount)
+
+// Grouped aggregation
+FROM logs-*
+| STATS count = COUNT(*) BY status_code
+
+// Multiple groupings
+FROM sales
+| STATS total = SUM(amount) BY region, product_category
+
+// Time-based grouping
+FROM logs-*
+| STATS count = COUNT(*) BY bucket = DATE_TRUNC(1 hour, @timestamp)
+```
+
+### KEEP
+
+Keeps only specified columns.
+
+**Syntax:**
+
+```
+KEEP column1 [, column2, ...]
+```
+
+**Examples:**
+
+```esql
+FROM employees
+| KEEP first_name, last_name, salary
+
+// With wildcards
+FROM logs-*
+| KEEP @timestamp, message, error.*
+```
+
+### DROP
+
+Removes specified columns.
+
+**Syntax:**
+
+```
+DROP column1 [, column2, ...]
+```
+
+**Examples:**
+
+```esql
+FROM employees
+| DROP internal_id, temp_field
+
+// With wildcards
+FROM data
+| DROP temp_*, debug_*
+```
+
+### RENAME
+
+Renames columns.
+
+**Syntax:**
+
+```
+RENAME old_name AS new_name [, old_name2 AS new_name2, ...]
+```
+
+**Examples:**
+
+```esql
+FROM employees
+| RENAME emp_id AS employee_id
+
+FROM data
+| RENAME col1 AS column_one, col2 AS column_two
+```
+
+### SORT
+
+Sorts the table.
+
+**Syntax:**
+
+```
+SORT column1 [ASC/DESC] [NULLS FIRST/LAST] [, column2 ...]
+```
+
+**Examples:**
+
+```esql
+FROM employees
+| SORT salary DESC
+
+FROM logs-*
+| SORT @timestamp DESC, severity ASC
+
+FROM data
+| SORT value ASC NULLS LAST
+```
+
+### LIMIT
+
+Limits the number of rows returned.
+
+**Syntax:**
+
+```
+LIMIT number
+```
+
+**Examples:**
+
+```esql
+FROM logs-*
+| SORT @timestamp DESC
+| LIMIT 100
+```
+
+### DISSECT
+
+Extracts structured fields from a string using a pattern.
+
+**Syntax:**
+
+```
+DISSECT field "%{pattern}"
+```
+
+**Examples:**
+
+```esql
+FROM logs
+| DISSECT message "%{clientip} - - [%{timestamp}] \"%{method} %{path}\""
+
+FROM apache_logs
+| DISSECT message "%{ip} %{} %{} [%{timestamp}] \"%{request}\" %{status} %{bytes}"
+```
+
+### GROK
+
+Extracts fields using grok patterns (regex-based).
+
+**Syntax:**
+
+```
+GROK field "%{PATTERN:field_name}"
+```
+
+**Common Patterns:**
+
+- `%{IP:ip}` - IP address
+- `%{NUMBER:num}` - Number
+- `%{WORD:word}` - Word
+- `%{DATA:data}` - Any data (non-greedy)
+- `%{GREEDYDATA:text}` - Any data (greedy)
+- `%{TIMESTAMP_ISO8601:ts}` - ISO timestamp
+
+**Examples:**
+
+```esql
+FROM logs
+| GROK message "%{IP:client_ip} %{WORD:method} %{NUMBER:status:int}"
+
+FROM web_logs
+| GROK agent "%{WORD:browser}/%{NUMBER:version}"
+```
+
+### ENRICH
+
+Enriches data by looking up values from an enrich policy.
+
+**Syntax:**
+
+```
+ENRICH policy_name ON match_field [WITH new_field1, new_field2, ...]
+```
+
+**Examples:**
+
+```esql
+FROM logs
+| ENRICH geo_policy ON client_ip WITH country, city
+
+FROM sales
+| ENRICH products_policy ON product_id WITH product_name, category
+```
+
+### MV_EXPAND
+
+Expands multivalued fields into separate rows.
+
+**Syntax:**
+
+```
+MV_EXPAND field
+```
+
+**Examples:**
+
+```esql
+FROM data
+| MV_EXPAND tags
+| STATS count = COUNT(*) BY tags
+```
+
+### LOOKUP JOIN
+
+Joins with a lookup index.
+
+**Syntax:**
+
+```
+LOOKUP JOIN index ON field
+```
+
+**Examples:**
+
+```esql
+FROM orders
+| LOOKUP JOIN customers ON customer_id
+```
+
+---
+
+## Aggregate Functions
+
+Used with STATS command.
+
+| Function                    | Description           | Example                                    |
+| --------------------------- | --------------------- | ------------------------------------------ |
+| `COUNT(*)`                  | Count all rows        | `STATS n = COUNT(*)`                       |
+| `COUNT(field)`              | Count non-null values | `STATS n = COUNT(status)`                  |
+| `COUNT_DISTINCT(field)`     | Count unique values   | `STATS unique = COUNT_DISTINCT(user_id)`   |
+| `SUM(field)`                | Sum of values         | `STATS total = SUM(amount)`                |
+| `AVG(field)`                | Average               | `STATS avg_price = AVG(price)`             |
+| `MIN(field)`                | Minimum value         | `STATS min_temp = MIN(temperature)`        |
+| `MAX(field)`                | Maximum value         | `STATS max_score = MAX(score)`             |
+| `MEDIAN(field)`             | Median value          | `STATS med = MEDIAN(response_time)`        |
+| `PERCENTILE(field, p)`      | Percentile            | `STATS p95 = PERCENTILE(latency, 95)`      |
+| `STD_DEV(field)`            | Standard deviation    | `STATS sd = STD_DEV(values)`               |
+| `VARIANCE(field)`           | Variance              | `STATS var = VARIANCE(values)`             |
+| `VALUES(field)`             | Collect all values    | `STATS all_tags = VALUES(tag)`             |
+| `TOP(field, n, order)`      | Top N values          | `STATS top3 = TOP(score, 3, "desc")`       |
+| `WEIGHTED_AVG(val, weight)` | Weighted average      | `STATS wavg = WEIGHTED_AVG(score, weight)` |
+
+---
+
+## String Functions
+
+| Function                   | Description         | Example                                     |
+| -------------------------- | ------------------- | ------------------------------------------- |
+| `LENGTH(s)`                | String length       | `EVAL len = LENGTH(name)`                   |
+| `CONCAT(s1, s2, ...)`      | Concatenate strings | `EVAL full = CONCAT(first, " ", last)`      |
+| `SUBSTRING(s, start, len)` | Extract substring   | `EVAL sub = SUBSTRING(text, 1, 10)`         |
+| `LEFT(s, n)`               | Left n characters   | `EVAL l = LEFT(text, 5)`                    |
+| `RIGHT(s, n)`              | Right n characters  | `EVAL r = RIGHT(text, 5)`                   |
+| `TRIM(s)`                  | Remove whitespace   | `EVAL clean = TRIM(input)`                  |
+| `LTRIM(s)`                 | Trim left           | `EVAL clean = LTRIM(input)`                 |
+| `RTRIM(s)`                 | Trim right          | `EVAL clean = RTRIM(input)`                 |
+| `TO_UPPER(s)`              | Uppercase           | `EVAL upper = TO_UPPER(name)`               |
+| `TO_LOWER(s)`              | Lowercase           | `EVAL lower = TO_LOWER(name)`               |
+| `REPLACE(s, old, new)`     | Replace text        | `EVAL fixed = REPLACE(msg, "err", "error")` |
+| `SPLIT(s, delim)`          | Split into array    | `EVAL parts = SPLIT(path, "/")`             |
+| `STARTS_WITH(s, prefix)`   | Check prefix        | `WHERE STARTS_WITH(url, "https")`           |
+| `ENDS_WITH(s, suffix)`     | Check suffix        | `WHERE ENDS_WITH(file, ".log")`             |
+| `CONTAINS(s, substr)`      | Check contains      | `WHERE CONTAINS(message, "error")`          |
+| `LOCATE(substr, s)`        | Find position       | `EVAL pos = LOCATE("@", email)`             |
+| `REVERSE(s)`               | Reverse string      | `EVAL rev = REVERSE(text)`                  |
+| `REPEAT(s, n)`             | Repeat string       | `EVAL sep = REPEAT("-", 10)`                |
+| `SPACE(n)`                 | N spaces            | `EVAL spaces = SPACE(5)`                    |
+
+---
+
+## Math Functions
+
+| Function                        | Description       | Example                                  |
+| ------------------------------- | ----------------- | ---------------------------------------- |
+| `ABS(n)`                        | Absolute value    | `EVAL abs_val = ABS(diff)`               |
+| `ROUND(n, decimals)`            | Round             | `EVAL rounded = ROUND(price, 2)`         |
+| `FLOOR(n)`                      | Round down        | `EVAL floored = FLOOR(value)`            |
+| `CEIL(n)`                       | Round up          | `EVAL ceiled = CEIL(value)`              |
+| `SQRT(n)`                       | Square root       | `EVAL root = SQRT(area)`                 |
+| `POW(base, exp)`                | Power             | `EVAL squared = POW(x, 2)`               |
+| `EXP(n)`                        | e^n               | `EVAL e_power = EXP(x)`                  |
+| `LOG(n)`                        | Natural log       | `EVAL ln = LOG(value)`                   |
+| `LOG10(n)`                      | Log base 10       | `EVAL log = LOG10(value)`                |
+| `SIN(n)`, `COS(n)`, `TAN(n)`    | Trig functions    | `EVAL sine = SIN(angle)`                 |
+| `ASIN(n)`, `ACOS(n)`, `ATAN(n)` | Inverse trig      | `EVAL angle = ASIN(ratio)`               |
+| `PI()`                          | Pi constant       | `EVAL circumference = 2 * PI() * radius` |
+| `E()`                           | Euler's number    | `EVAL e = E()`                           |
+| `SIGNUM(n)`                     | Sign (-1, 0, 1)   | `EVAL sign = SIGNUM(value)`              |
+| `GREATEST(a, b, ...)`           | Maximum of values | `EVAL max = GREATEST(a, b, c)`           |
+| `LEAST(a, b, ...)`              | Minimum of values | `EVAL min = LEAST(a, b, c)`              |
+
+---
+
+## Date/Time Functions
+
+| Function                     | Description          | Example                                      |
+| ---------------------------- | -------------------- | -------------------------------------------- |
+| `NOW()`                      | Current timestamp    | `WHERE @timestamp > NOW() - 1 hour`          |
+| `DATE_TRUNC(interval, date)` | Truncate to interval | `EVAL hour = DATE_TRUNC(1 hour, @timestamp)` |
+| `DATE_EXTRACT(part, date)`   | Extract part         | `EVAL month = DATE_EXTRACT(month, date)`     |
+| `DATE_FORMAT(pattern, date)` | Format date          | `EVAL str = DATE_FORMAT("yyyy-MM-dd", date)` |
+| `DATE_PARSE(pattern, str)`   | Parse date string    | `EVAL dt = DATE_PARSE("yyyy-MM-dd", str)`    |
+| `DATE_DIFF(unit, d1, d2)`    | Difference           | `EVAL days = DATE_DIFF("day", start, end)`   |
+
+**Time units:** `millisecond`, `second`, `minute`, `hour`, `day`, `week`, `month`, `year`
+
+**Timespan literals:** `1 day`, `2 hours`, `30 minutes`, `1 week`
+
+---
+
+## Type Conversion Functions
+
+| Function         | Description         | Example                       |
+| ---------------- | ------------------- | ----------------------------- |
+| `TO_STRING(v)`   | Convert to string   | `EVAL str = TO_STRING(num)`   |
+| `TO_INTEGER(v)`  | Convert to integer  | `EVAL int = TO_INTEGER(str)`  |
+| `TO_LONG(v)`     | Convert to long     | `EVAL lng = TO_LONG(str)`     |
+| `TO_DOUBLE(v)`   | Convert to double   | `EVAL dbl = TO_DOUBLE(str)`   |
+| `TO_BOOLEAN(v)`  | Convert to boolean  | `EVAL bool = TO_BOOLEAN(str)` |
+| `TO_DATETIME(v)` | Convert to datetime | `EVAL dt = TO_DATETIME(str)`  |
+| `TO_IP(v)`       | Convert to IP       | `EVAL ip = TO_IP(str)`        |
+| `TO_VERSION(v)`  | Convert to version  | `EVAL ver = TO_VERSION(str)`  |
+
+---
+
+## Multivalue Functions
+
+For handling fields with multiple values.
+
+| Function                      | Description       | Example                              |
+| ----------------------------- | ----------------- | ------------------------------------ |
+| `MV_COUNT(field)`             | Count values      | `EVAL n = MV_COUNT(tags)`            |
+| `MV_FIRST(field)`             | First value       | `EVAL first = MV_FIRST(values)`      |
+| `MV_LAST(field)`              | Last value        | `EVAL last = MV_LAST(values)`        |
+| `MV_MIN(field)`               | Minimum           | `EVAL min = MV_MIN(scores)`          |
+| `MV_MAX(field)`               | Maximum           | `EVAL max = MV_MAX(scores)`          |
+| `MV_SUM(field)`               | Sum               | `EVAL total = MV_SUM(amounts)`       |
+| `MV_AVG(field)`               | Average           | `EVAL avg = MV_AVG(scores)`          |
+| `MV_MEDIAN(field)`            | Median            | `EVAL med = MV_MEDIAN(values)`       |
+| `MV_CONCAT(field, delim)`     | Join to string    | `EVAL str = MV_CONCAT(tags, ", ")`   |
+| `MV_DEDUPE(field)`            | Remove duplicates | `EVAL unique = MV_DEDUPE(tags)`      |
+| `MV_SORT(field)`              | Sort values       | `EVAL sorted = MV_SORT(values)`      |
+| `MV_SLICE(field, start, end)` | Slice array       | `EVAL slice = MV_SLICE(arr, 0, 3)`   |
+| `MV_ZIP(f1, f2)`              | Zip arrays        | `EVAL zipped = MV_ZIP(keys, values)` |
+
+---
+
+## Conditional Functions
+
+| Function                          | Description    | Example                                                    |
+| --------------------------------- | -------------- | ---------------------------------------------------------- |
+| `CASE(cond1, val1, ..., default)` | Conditional    | `EVAL level = CASE(score > 90, "A", score > 80, "B", "C")` |
+| `COALESCE(v1, v2, ...)`           | First non-null | `EVAL name = COALESCE(nickname, full_name, "Unknown")`     |
+| `NULLIF(v1, v2)`                  | Null if equal  | `EVAL val = NULLIF(x, 0)`                                  |
+| `IS_NULL(field)`                  | Check null     | `WHERE IS_NULL(error)`                                     |
+| `IS_NOT_NULL(field)`              | Check not null | `WHERE IS_NOT_NULL(response)`                              |
+
+---
+
+## Full-Text Search Functions
+
+For text search with analyzer support (available since 8.17+).
+
+### MATCH
+
+Basic text search.
+
+```esql
+FROM articles
+| WHERE MATCH(content, "elasticsearch query")
+
+// With options
+FROM docs
+| WHERE MATCH(title, "search", {"operator": "AND"})
+```
+
+### MATCH (colon operator)
+
+Shorthand for MATCH.
+
+```esql
+FROM logs
+| WHERE message : "error"
+```
+
+### QSTR (Query String)
+
+Complex queries using query string syntax.
+
+```esql
+FROM logs
+| WHERE QSTR("status:error AND (type:critical OR type:warning)")
+```
+
+### KQL
+
+Kibana Query Language support.
+
+```esql
+FROM logs
+| WHERE KQL("message: error and host.name: server*")
+```
+
+### Relevance Scoring
+
+```esql
+FROM articles METADATA _score
+| WHERE MATCH(content, "elasticsearch")
+| SORT _score DESC
+| LIMIT 10
+```
+
+---
+
+## Operators
+
+### Comparison Operators
+
+- `==` Equal
+- `!=` Not equal
+- `<`, `<=`, `>`, `>=` Comparison
+- `IS NULL`, `IS NOT NULL` Null checks
+
+### Logical Operators
+
+- `AND` Logical AND
+- `OR` Logical OR
+- `NOT` Logical NOT
+
+### Pattern Matching
+
+- `LIKE` Wildcard pattern (`%` any chars, `_` single char)
+- `RLIKE` Regular expression
+- `IN` Value in list
+
+**Examples:**
+
+```esql
+WHERE name LIKE "John%"
+WHERE email RLIKE ".*@example\\.com"
+WHERE status IN ("active", "pending")
+WHERE NOT (status == "deleted")
+```
+
+### Arithmetic Operators
+
+- `+`, `-`, `*`, `/`, `%` (modulo)
+
+---
+
+## Comments
+
+```esql
+// Single line comment
+
+/* Multi-line
+   comment */
+
+FROM logs  // inline comment
+| WHERE status == 200
+```
+
+---
+
+## Metadata Fields
+
+Access document metadata with `METADATA` clause.
+
+```esql
+FROM logs METADATA _id, _index, _version
+| KEEP _id, message
+```
+
+Available metadata: `_id`, `_index`, `_version`, `_score` (for search)
+
+---
+
+## Best Practices
+
+1. **Always use LIMIT** to avoid returning too many rows
+2. **Filter early** with WHERE to reduce data processed
+3. **Use KEEP** to select only needed columns
+4. **Use appropriate data types** for comparisons
+5. **Use STATS for aggregations** instead of returning all rows
+6. **Use DATE_TRUNC for time-based grouping**
+7. **Leverage full-text functions** (MATCH, QSTR) for text search - much faster than LIKE/RLIKE
+
+---
+
+## Example Queries
+
+### Log Analysis
+
+```esql
+FROM logs-*
+| WHERE @timestamp > NOW() - 24 hours
+| WHERE status_code >= 400
+| STATS error_count = COUNT(*) BY status_code, host.name
+| SORT error_count DESC
+| LIMIT 20
+```
+
+### User Activity
+
+```esql
+FROM user_events
+| WHERE event_type == "login"
+| EVAL hour = DATE_TRUNC(1 hour, @timestamp)
+| STATS logins = COUNT(*), unique_users = COUNT_DISTINCT(user_id) BY hour
+| SORT hour DESC
+```
+
+### Performance Metrics
+
+```esql
+FROM metrics-*
+| WHERE @timestamp > NOW() - 1 hour
+| STATS
+    avg_response = AVG(response_time),
+    p95_response = PERCENTILE(response_time, 95),
+    max_response = MAX(response_time)
+  BY service.name
+| SORT avg_response DESC
+```
+
+### Text Search with Scoring
+
+```esql
+FROM articles METADATA _score
+| WHERE MATCH(content, "machine learning")
+| KEEP title, author, _score
+| SORT _score DESC
+| LIMIT 10
+```
+
+### Data Transformation
+
+```esql
+FROM raw_logs
+| GROK message "%{IP:client_ip} - %{WORD:method} %{URIPATHPARAM:path} %{NUMBER:status:int}"
+| EVAL is_error = status >= 400
+| STATS
+    total = COUNT(*),
+    errors = COUNT(CASE(is_error, 1, null))
+  BY client_ip
+| EVAL error_rate = ROUND(errors * 100.0 / total, 2)
+| SORT error_rate DESC
+```

--- a/skills/esql/references/generation-tips.md
+++ b/skills/esql/references/generation-tips.md
@@ -1,0 +1,332 @@
+# ES|QL Query Generation Tips
+
+Guidelines for generating accurate ES|QL queries from natural language.
+
+## Step-by-Step Generation Process
+
+### 1. Identify the Data Source
+
+**Question:** What index or data should be queried?
+
+- Look for index names, data types, or subject areas mentioned
+- Common patterns: `logs-*`, `metrics-*`, `events-*`, `apm-*`
+- If unclear, use wildcards or ask for clarification
+
+```esql
+FROM logs-*           // Generic logs
+FROM metrics-*        // Metrics data
+FROM .ds-*            // Data streams
+FROM my-index-2024.*  // Dated indices
+```
+
+### 2. Determine Time Range
+
+**Question:** What time period should be covered?
+
+| User Expression | ES\|QL                                                             |
+| --------------- | ------------------------------------------------------------------ |
+| "last hour"     | `@timestamp > NOW() - 1 hour`                                      |
+| "last 24 hours" | `@timestamp > NOW() - 24 hours`                                    |
+| "last 7 days"   | `@timestamp > NOW() - 7 days`                                      |
+| "today"         | `@timestamp > NOW() - 24 hours`                                    |
+| "yesterday"     | `@timestamp >= NOW() - 48 hours AND @timestamp < NOW() - 24 hours` |
+| "this week"     | `@timestamp > NOW() - 7 days`                                      |
+| "this month"    | `@timestamp > NOW() - 30 days`                                     |
+
+**Default:** If no time range specified, consider adding a reasonable default (e.g., last 24 hours) to avoid scanning too much data.
+
+### 3. Identify Filters
+
+**Question:** What conditions should narrow the results?
+
+Look for:
+
+- Status/level: "errors", "warnings", "successful"
+- Environment: "production", "staging", "dev"
+- Source/host: specific servers, services, applications
+- Values: specific codes, IDs, names
+
+```esql
+// Multiple filters
+| WHERE level == "error"
+| WHERE environment == "production"
+| WHERE service.name == "api-gateway"
+```
+
+Or combined:
+
+```esql
+| WHERE level == "error" AND environment == "production" AND service.name == "api-gateway"
+```
+
+### 4. Determine Output Type
+
+**Question:** Does the user want raw data or aggregated results?
+
+| User Intent                   | Approach                        |
+| ----------------------------- | ------------------------------- |
+| "show me", "list", "find"     | Raw data with KEEP, SORT, LIMIT |
+| "count", "how many"           | STATS with COUNT                |
+| "average", "total", "sum"     | STATS with aggregation function |
+| "by X", "per X", "grouped by" | STATS ... BY grouping           |
+| "top N", "most common"        | STATS + SORT DESC + LIMIT       |
+| "distribution", "breakdown"   | STATS COUNT BY category         |
+| "over time", "trend"          | STATS BY DATE_TRUNC             |
+
+### 5. Select Fields
+
+**Question:** What fields should be shown?
+
+For raw data queries, use KEEP to select relevant fields:
+
+```esql
+| KEEP @timestamp, host.name, message, level
+```
+
+For aggregations, the output fields are defined by STATS:
+
+```esql
+| STATS count = COUNT(*), avg_time = AVG(response_time) BY endpoint
+```
+
+### 6. Apply Ordering and Limits
+
+**Question:** How should results be ordered and limited?
+
+- Time-based: `SORT @timestamp DESC`
+- By count/value: `SORT count DESC`
+- Alphabetical: `SORT name ASC`
+
+**Always add LIMIT** unless the user specifically wants all results:
+
+```esql
+| LIMIT 100  // Reasonable default
+| LIMIT 1000 // Maximum before considering pagination
+```
+
+---
+
+## Field Name Conventions
+
+When generating queries, use common field naming conventions:
+
+### Elastic Common Schema (ECS)
+
+| Category    | Common Fields                                                  |
+| ----------- | -------------------------------------------------------------- |
+| Timestamp   | `@timestamp`                                                   |
+| Message     | `message`                                                      |
+| Log level   | `log.level`, `level`                                           |
+| Host        | `host.name`, `host.ip`                                         |
+| Service     | `service.name`, `service.type`                                 |
+| HTTP        | `http.request.method`, `http.response.status_code`, `url.path` |
+| User        | `user.name`, `user.id`                                         |
+| Source      | `source.ip`, `source.port`                                     |
+| Destination | `destination.ip`, `destination.port`                           |
+| Error       | `error.message`, `error.type`                                  |
+| Event       | `event.action`, `event.category`, `event.outcome`              |
+
+### Legacy/Custom Fields
+
+Some indices may use non-ECS field names:
+
+- `status_code` instead of `http.response.status_code`
+- `hostname` instead of `host.name`
+- `timestamp` instead of `@timestamp`
+
+**Recommendation:** When unsure, use `./esql.js schema <index>` to discover actual field names.
+
+---
+
+## Query Optimization Tips
+
+### 1. Filter Early
+
+Put WHERE clauses as early as possible:
+
+```esql
+// Good - filter first
+FROM logs-*
+| WHERE @timestamp > NOW() - 1 hour
+| WHERE level == "error"
+| STATS count = COUNT(*) BY host.name
+
+// Less efficient - filtering after processing
+FROM logs-*
+| STATS count = COUNT(*) BY host.name, level
+| WHERE level == "error"
+```
+
+### 2. Use Appropriate Time Ranges
+
+Smaller time ranges = faster queries:
+
+```esql
+// Specific range is faster
+| WHERE @timestamp > NOW() - 1 hour
+
+// Than scanning all data
+// (no time filter)
+```
+
+### 3. Limit Fields
+
+Only keep fields you need:
+
+```esql
+// Good - specific fields
+| KEEP @timestamp, message, host.name
+
+// Less efficient - all fields
+// (no KEEP command)
+```
+
+### 4. Use LIMIT
+
+Prevent returning excessive rows:
+
+```esql
+| LIMIT 100  // Always include for raw data queries
+```
+
+---
+
+## Common Query Templates
+
+### Error Investigation
+
+```esql
+FROM logs-*
+| WHERE @timestamp > NOW() - 1 hour
+| WHERE level == "error"
+| KEEP @timestamp, message, host.name, service.name, error.message
+| SORT @timestamp DESC
+| LIMIT 100
+```
+
+### Service Health Overview
+
+```esql
+FROM metrics-*
+| WHERE @timestamp > NOW() - 15 minutes
+| STATS
+    avg_cpu = AVG(system.cpu.percent),
+    avg_mem = AVG(system.memory.used.pct),
+    host_count = COUNT_DISTINCT(host.name)
+  BY service.name
+| SORT avg_cpu DESC
+```
+
+### API Performance Analysis
+
+```esql
+FROM apm-*
+| WHERE @timestamp > NOW() - 1 hour
+| STATS
+    count = COUNT(*),
+    avg_duration = AVG(transaction.duration.us),
+    p95_duration = PERCENTILE(transaction.duration.us, 95),
+    error_count = COUNT(CASE(transaction.result != "success", 1, null))
+  BY transaction.name
+| EVAL error_rate = ROUND(error_count * 100.0 / count, 2)
+| SORT count DESC
+| LIMIT 20
+```
+
+### Traffic Analysis
+
+```esql
+FROM web-logs
+| WHERE @timestamp > NOW() - 24 hours
+| STATS
+    requests = COUNT(*),
+    unique_ips = COUNT_DISTINCT(client.ip)
+  BY hour = DATE_TRUNC(1 hour, @timestamp)
+| SORT hour DESC
+```
+
+### Security Event Review
+
+```esql
+FROM security-*
+| WHERE @timestamp > NOW() - 24 hours
+| WHERE event.category == "authentication"
+| WHERE event.outcome == "failure"
+| STATS
+    failures = COUNT(*)
+  BY user.name, source.ip
+| WHERE failures > 5
+| SORT failures DESC
+```
+
+---
+
+## Handling Ambiguity
+
+When the user request is ambiguous:
+
+### Missing Index
+
+If no index specified, make a reasonable assumption:
+
+- "show errors" → `FROM logs-*`
+- "show CPU usage" → `FROM metrics-*`
+- "show requests" → `FROM web-logs` or `FROM access-*`
+
+Or output the query with a placeholder and note:
+
+```esql
+FROM <index-pattern>  // Specify your index
+| WHERE ...
+```
+
+### Missing Time Range
+
+Add a sensible default:
+
+```esql
+| WHERE @timestamp > NOW() - 24 hours  // Default: last 24 hours
+```
+
+### Unclear Aggregation
+
+When "show X" could mean list or count:
+
+- If followed by "by Y" → aggregation
+- If asking for specifics → raw data
+- If asking "how many" → count
+- Default to raw data with limit
+
+### Unknown Field Names
+
+If field names are uncertain:
+
+1. Use common ECS names as first guess
+2. Suggest running schema discovery
+3. Note the assumption in output
+
+---
+
+## Output Formatting Suggestions
+
+When presenting generated queries:
+
+```
+=== ES|QL Query ===
+
+FROM logs-*
+| WHERE @timestamp > NOW() - 1 hour
+| WHERE level == "error"
+| STATS count = COUNT(*) BY host.name
+| SORT count DESC
+| LIMIT 10
+
+=== Explanation ===
+- Queries all log indices
+- Filters to the last hour
+- Counts errors per host
+- Returns top 10 hosts by error count
+
+=== To Execute ===
+./esql.js raw "FROM logs-* | WHERE @timestamp > NOW() - 1 hour | WHERE level == \"error\" | STATS count = COUNT(*) BY host.name | SORT count DESC | LIMIT 10"
+```

--- a/skills/esql/references/query-patterns.md
+++ b/skills/esql/references/query-patterns.md
@@ -1,0 +1,374 @@
+# ES|QL Query Patterns
+
+Common patterns for generating ES|QL queries from natural language requests.
+
+## Pattern Recognition Guide
+
+When translating natural language to ES|QL, identify these key elements:
+
+| User Says                               | ES\|QL Element                            |
+| --------------------------------------- | ----------------------------------------- |
+| "show", "list", "get", "find"           | `FROM` + `KEEP` (select fields)           |
+| "from", "in" (index)                    | `FROM index-pattern`                      |
+| "where", "with", "that have", "filter"  | `WHERE condition`                         |
+| "last X hours/days", "since", "between" | `WHERE @timestamp > NOW() - X time`       |
+| "count", "how many"                     | `STATS count = COUNT(*)`                  |
+| "average", "mean"                       | `STATS avg = AVG(field)`                  |
+| "total", "sum"                          | `STATS total = SUM(field)`                |
+| "maximum", "highest", "top value"       | `STATS max = MAX(field)`                  |
+| "minimum", "lowest"                     | `STATS min = MIN(field)`                  |
+| "by", "per", "grouped by", "for each"   | `... BY field`                            |
+| "top N", "first N", "limit"             | `LIMIT N`                                 |
+| "sorted by", "order by"                 | `SORT field [DESC/ASC]`                   |
+| "unique", "distinct"                    | `COUNT_DISTINCT(field)`                   |
+| "contains", "includes"                  | `WHERE field LIKE "*value*"` or `MATCH()` |
+| "starts with"                           | `WHERE STARTS_WITH(field, "prefix")`      |
+| "ends with"                             | `WHERE ENDS_WITH(field, "suffix")`        |
+
+---
+
+## Time-Based Queries
+
+### Recent Data
+
+```
+"show errors from the last hour"
+→
+FROM logs-*
+| WHERE @timestamp > NOW() - 1 hour
+| WHERE level == "error"
+| SORT @timestamp DESC
+| LIMIT 100
+```
+
+### Time Range
+
+```
+"events between January 1 and January 15, 2024"
+→
+FROM events-*
+| WHERE @timestamp >= "2024-01-01" AND @timestamp < "2024-01-16"
+```
+
+### Time Bucketing
+
+```
+"count events per hour for today"
+→
+FROM events-*
+| WHERE @timestamp > NOW() - 24 hours
+| STATS count = COUNT(*) BY bucket = DATE_TRUNC(1 hour, @timestamp)
+| SORT bucket DESC
+```
+
+### Time Comparisons
+
+```
+"requests slower than 5 seconds"
+→
+FROM api-logs
+| WHERE response_time > 5000
+| SORT response_time DESC
+| LIMIT 100
+```
+
+---
+
+## Aggregation Patterns
+
+### Simple Count
+
+```
+"how many errors are there"
+→
+FROM logs-*
+| WHERE level == "error"
+| STATS total_errors = COUNT(*)
+```
+
+### Count by Category
+
+```
+"count of events by status code"
+→
+FROM web-logs
+| STATS count = COUNT(*) BY status_code
+| SORT count DESC
+```
+
+### Multiple Aggregations
+
+```
+"show min, max, and average response time"
+→
+FROM api-logs
+| STATS
+    min_time = MIN(response_time),
+    max_time = MAX(response_time),
+    avg_time = AVG(response_time)
+```
+
+### Grouped Multiple Aggregations
+
+```
+"average and max CPU per host"
+→
+FROM metrics-*
+| STATS
+    avg_cpu = AVG(system.cpu.percent),
+    max_cpu = MAX(system.cpu.percent)
+  BY host.name
+| SORT avg_cpu DESC
+```
+
+### Top N Pattern
+
+```
+"top 10 hosts by error count"
+→
+FROM logs-*
+| WHERE level == "error"
+| STATS error_count = COUNT(*) BY host.name
+| SORT error_count DESC
+| LIMIT 10
+```
+
+### Percentiles
+
+```
+"p50, p95, p99 response times by endpoint"
+→
+FROM api-logs
+| STATS
+    p50 = PERCENTILE(response_time, 50),
+    p95 = PERCENTILE(response_time, 95),
+    p99 = PERCENTILE(response_time, 99)
+  BY endpoint
+| SORT p99 DESC
+```
+
+### Unique Counts
+
+```
+"count of unique users per day"
+→
+FROM user-events
+| STATS unique_users = COUNT_DISTINCT(user_id) BY day = DATE_TRUNC(1 day, @timestamp)
+| SORT day DESC
+```
+
+---
+
+## Filtering Patterns
+
+### Exact Match
+
+```
+"errors from production"
+→
+FROM logs-*
+| WHERE level == "error" AND environment == "production"
+```
+
+### Multiple Values (IN)
+
+```
+"events with status 400, 401, or 403"
+→
+FROM web-logs
+| WHERE status_code IN (400, 401, 403)
+```
+
+### Pattern Matching
+
+```
+"requests to /api endpoints"
+→
+FROM web-logs
+| WHERE url LIKE "/api/*"
+```
+
+### Full-Text Search (8.17+)
+
+```
+"documents containing 'connection timeout'"
+→
+FROM logs-* METADATA _score
+| WHERE MATCH(message, "connection timeout")
+| SORT _score DESC
+| LIMIT 100
+```
+
+### Null Handling
+
+```
+"records where error field exists"
+→
+FROM logs-*
+| WHERE error IS NOT NULL
+```
+
+### Negation
+
+```
+"all events except from test environment"
+→
+FROM events-*
+| WHERE environment != "test"
+```
+
+---
+
+## Transformation Patterns
+
+### Computed Fields
+
+```
+"show response time in seconds"
+→
+FROM api-logs
+| EVAL response_time_sec = response_time_ms / 1000
+| KEEP endpoint, response_time_sec
+```
+
+### String Manipulation
+
+```
+"extract domain from email addresses"
+→
+FROM users
+| EVAL domain = SUBSTRING(email, LOCATE("@", email) + 1, LENGTH(email))
+| KEEP email, domain
+```
+
+### Conditional Values
+
+```
+"categorize response times as fast/medium/slow"
+→
+FROM api-logs
+| EVAL speed_category = CASE(
+    response_time < 100, "fast",
+    response_time < 500, "medium",
+    "slow"
+  )
+| STATS count = COUNT(*) BY speed_category
+```
+
+### Rate Calculation
+
+```
+"error rate percentage by service"
+→
+FROM logs-*
+| STATS
+    total = COUNT(*),
+    errors = COUNT(CASE(level == "error", 1, null))
+  BY service.name
+| EVAL error_rate = ROUND(errors * 100.0 / total, 2)
+| SORT error_rate DESC
+```
+
+---
+
+## Log Parsing Patterns
+
+### GROK for Structured Extraction
+
+```
+"parse Apache access logs"
+→
+FROM raw-logs
+| GROK message "%{IP:client_ip} - - \\[%{HTTPDATE:timestamp}\\] \"%{WORD:method} %{URIPATHPARAM:path} HTTP/%{NUMBER:http_version}\" %{NUMBER:status:int} %{NUMBER:bytes:int}"
+| KEEP client_ip, method, path, status, bytes
+```
+
+### DISSECT for Simple Patterns
+
+```
+"extract user and action from 'User X performed Y'"
+→
+FROM audit-logs
+| DISSECT message "User %{user} performed %{action}"
+| STATS count = COUNT(*) BY user, action
+```
+
+---
+
+## Advanced Patterns
+
+### Multi-Index Query
+
+```
+"combine data from logs and metrics"
+→
+FROM logs-*, metrics-*
+| WHERE @timestamp > NOW() - 1 hour
+| KEEP @timestamp, host.name, message, cpu.percent
+```
+
+### Data Enrichment
+
+```
+"add geo info to IP addresses"
+→
+FROM web-logs
+| ENRICH geoip-policy ON client.ip WITH country_name, city_name
+| STATS requests = COUNT(*) BY country_name
+| SORT requests DESC
+```
+
+### Multivalue Handling
+
+```
+"count occurrences of each tag"
+→
+FROM documents
+| MV_EXPAND tags
+| STATS count = COUNT(*) BY tags
+| SORT count DESC
+```
+
+### Chained Aggregations
+
+```
+"average daily count per week"
+→
+FROM events
+| STATS daily_count = COUNT(*) BY day = DATE_TRUNC(1 day, @timestamp)
+| STATS avg_daily = AVG(daily_count) BY week = DATE_TRUNC(1 week, day)
+| SORT week DESC
+```
+
+---
+
+## Common Mistakes to Avoid
+
+1. **Forgetting LIMIT** - Always add `LIMIT` to prevent returning too many rows
+
+2. **Wrong time field** - Common names: `@timestamp`, `timestamp`, `time`, `date`
+
+3. **Case sensitivity** - Field names are case-sensitive: `host.Name` ≠ `host.name`
+
+4. **String vs Keyword** - Use `.keyword` suffix for exact matches on text fields:
+
+   ```esql
+   WHERE status.keyword == "active"
+   ```
+
+5. **Type mismatches** - Convert types when needed:
+
+   ```esql
+   | EVAL num = TO_INTEGER(string_field)
+   ```
+
+6. **STATS without aggregation** - STATS requires aggregate functions:
+
+   ```esql
+   // Wrong: | STATS BY host
+   // Right: | STATS count = COUNT(*) BY host
+   ```
+
+7. **Missing FROM** - Every query must start with a source command
+
+8. **Pipe placement** - Each command needs a pipe before it (except FROM)


### PR DESCRIPTION
This PR adds a `skills` folder with a first [ES|QL](https://www.elastic.co/docs/reference/query-languages/esql) skill.
This skill enables Gemini to translate a natural language question into an ES|QL query.
In order to test it, you need to disable the `elastic-agent-builde` MCP (from gemini cli):
```
/mcp disable elastic-agent-builder
```
 and provide the `ELASTIC_URL` and `ELASTIC_API_KEY` ENV variables.

If you want to test, enable the `kibana_sample_data_ecommerce` data set in *Integrations > Sample data > Other sample data set* in Kibana. 
Try to ask the following question in Gemini CLI:
```
 Find the top 8 customers based in USA by total expense in kibana_sample_data_ecommerce Elasticsearch index                 
```